### PR TITLE
optimize

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,20 @@
-module.exports = moore
-
-function moore(range, dims) {
-  dims = dims || 2
+module.exports = function moore(range, dimensions) {
   range = range || 1
-  return recurse([], [], 0)
+  dimensions = dimensions || 2
 
-  function recurse(array, temp, d) {
-    if (d === dims-1) {
-      for (var i = -range; i <= range; i += 1) {
-        if (i || temp.some(function(n) {
-          return n
-        })) array.push(temp.concat(i))
-      }
-    } else {
-      for (var i = -range; i <= range; i += 1) {
-        recurse(array, temp.concat(i), d+1)
-      }
+  var size = range * 2 + 1
+  var length = Math.pow(size, dimensions) - 1
+  var neighbors = new Array(length)
+
+  for (var i = 0; i < length; i++) {
+    var neighbor = neighbors[i] = new Array(dimensions)
+    var index = i < length / 2 ? i : i + 1
+    for (var dimension = 1; dimension <= dimensions; dimension++) {
+      var value = index % Math.pow(size, dimension)
+      neighbor[dimension - 1] = value / Math.pow(size, dimension - 1) - range
+      index -= value
     }
-    return array
   }
+
+  return neighbors
 }


### PR DESCRIPTION
removed the recursion and cut down on array creation. New version is ~5x faster and still passes tests:thumbsup:

```
# new version 100000 times
ok ~1.66 s (1 s + 661692338 ns)

# old version 100000 times
ok ~8.73 s (8 s + 731867943 ns)
```

on the other hand i think all the `Math.pow` calls and the ternary (for ignoring the middle "red" cell) make it look messy. i'll put some thought into how to make it look more elegant